### PR TITLE
Implement code-level versioning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ set(MJSTR_INC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjstr/conversion.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjstr/string.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/mjstr/string_view.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mjstr/version.hpp"
 )
 set(MJSTR_SRC_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/mjstr/char_traits.cpp"

--- a/src/mjstr/version.hpp
+++ b/src/mjstr/version.hpp
@@ -1,0 +1,24 @@
+// version.hpp
+
+// Copyright (c) Mateusz Jandura. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#ifndef _MJSTR_VERSION_HPP_
+#define _MJSTR_VERSION_HPP_
+#include <mjmem/version.hpp>
+
+// Note: The core versioning macros are defined in <mjmem/version.hpp>. These macros serve as the basis
+//       for versioning in all modules. If a core library that forms the foundation for MJMEM is ever
+//       introduced, this inclusion should be updated accordingly.
+
+// defines the latest MJSTR library version, synchronized with the version specified in 'res/mjstr.rc'
+#define _MJSTR_VERSION_MAJOR 2ULL
+#define _MJSTR_VERSION_MINOR 0ULL
+#define _MJSTR_VERSION_PATCH 0ULL
+#define _MJSTR_VERSION       _MJX_ENCODE_VERSION(_MJSTR_VERSION_MAJOR, _MJSTR_VERSION_MINOR, _MJSTR_VERSION_PATCH)
+
+// checks whether the current version is greater than or equal to the specified version
+#define _MJSTR_VERSION_SUPPORTED(_Major, _Minor, _Patch) \
+    (_MJSTR_VERSION >= _MJX_ENCODE_VERSION(_Major, _Minor, _Patch))
+#endif // _MJSTR_VERSION_HPP_


### PR DESCRIPTION
Resolves #17

This feature does not require additional tests as they are already defined in the MJMEM library, where the core versioning macros are defined.